### PR TITLE
Remove deprecated "fromString" from minify

### DIFF
--- a/bookmarklet.js
+++ b/bookmarklet.js
@@ -48,7 +48,7 @@ function loadScript(code, path) {
 }
 
 function minify(code) {
-    return uglify.minify(code, {fromString: true}).code;
+    return uglify.minify(code).code;
 }
 
 function convert(code, options) {


### PR DESCRIPTION
This was removed from the minify method here:

https://github.com/mishoo/UglifyJS2/pull/1811

This should solve [issue 7](https://github.com/mrcoles/bookmarklet/issues/7)