### PR TITLE
Fix "NaN" output on cli invocation

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -16,14 +16,13 @@ if (['-V', '--version'].some(flag => args.indexOf(flag) !== -1)) {
 }
 
 function help() {
-  console.error(
-    `Bookmarklet v${bookmarklet.version.join(
-      '.'
-    )} usage: bookmarklet source [destination]
+  console.error(`
+Bookmarklet v${bookmarklet.version.join('.')}
 
-source      - path to file to read from or ` -
-      ` for stdin',
-destination - path to file to write to
+usage: bookmarklet source [destination]
+
+   source - path to file to read from or for stdin',
+   destination - path to file to write to
 
 More info: https://github.com/mrcoles/bookmarklet
     `


### PR DESCRIPTION
When I ran `node_modules/bookmarklet/bin/cli.js -h` I would just get "NaN" with Node v10.1.0; this fixes it.